### PR TITLE
#92 rdflib 6.2.0 upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests==2.26.0
 skosprovider==1.1.0
 #-e git+https://github.com/koenedaele/skosprovider.git@DEV_0.7.0#egg=skosprovider
-rdflib==5.0.0
+rdflib==6.2.0

--- a/skosprovider_getty/utils.py
+++ b/skosprovider_getty/utils.py
@@ -110,7 +110,7 @@ def _create_from_subject_typelist(graph, subject, typelist):
     list = []
     note_uris = []
     for p in typelist:
-        term = SKOS.term(p)
+        term = SKOS.__getitem__(p)
         list.extend(_create_from_subject_predicate(graph, subject, term, note_uris))
     return list
 
@@ -300,7 +300,7 @@ def uri_to_graph(uri, **kwargs):
     res = do_get_request(uri, s)
     if res.status_code == 404:
         return False
-    graph.parse(data=res.content)
+    graph.parse(data=res.content, format="application/rdf+xml")
     return graph
 
 


### PR DESCRIPTION
After #91 , tests might fail due to lower python version + RDFLib requirement of python > 3.6